### PR TITLE
Add fallback for all SampleableComponents

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NQCDistributions"
 uuid = "657014a1-bd25-4aa2-92cb-cbcede0310ad"
 authors = ["James Gardner <james.gardner1421@gmail.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"

--- a/src/dynamical_distribution.jl
+++ b/src/dynamical_distribution.jl
@@ -3,20 +3,27 @@ struct DynamicalDistribution{V,R}
     velocity::V
     position::R
     rng::Xoshiro
-    function DynamicalDistribution(velocity, position)
-        size(velocity) == size(position) || throw(
-            DimensionMismatch(
-                "`velocity` and `position` sample size does not match: \
-                $(size(velocity)) != $(size(position))"
-            )
-        )
-        return new{typeof(velocity),typeof(position)}(velocity, position, Xoshiro())
-    end
 end
 
-function DynamicalDistribution(velocity, position, dims)
+function DynamicalDistribution(velocity::SampleableComponent, position::SampleableComponent)
+    size(velocity) == size(position) || throw(
+        DimensionMismatch(
+            "`velocity` and `position` sample size does not match: \
+            $(size(velocity)) != $(size(position))"
+        )
+    )
+    return DynamicalDistribution(velocity, position, Xoshiro())
+end
+
+function DynamicalDistribution(velocity, position, dims::Dims{2})
     v = SampleableComponent(velocity, dims)
     r = SampleableComponent(position, dims)
+    return DynamicalDistribution(v, r)
+end
+
+function DynamicalDistribution(velocity, position, dims::Dims{3}; classical=Int[])
+    v = SampleableComponent(velocity, dims, classical)
+    r = SampleableComponent(position, dims, classical)
     return DynamicalDistribution(v, r)
 end
 

--- a/src/sampleable_components.jl
+++ b/src/sampleable_components.jl
@@ -1,10 +1,12 @@
 
+abstract type SampleableComponent end
+
 """
     UnivariateFill{S<:Sampleable{Univariate}}
   
 Fill all degrees of freedom from single Univariate distribution.
 """
-struct UnivariateFill{S<:Sampleable{Univariate}}
+struct UnivariateFill{S<:Sampleable{Univariate}} <: SampleableComponent
     sampleable::S
     dims::Dims{2}
 end
@@ -25,7 +27,7 @@ Fill each degree of freedom from a different Univariate distribution.
 
 The size of the matrix of sampleables should match the system size.
 """
-struct UnivariateArray{N,S<:Sampleable{Univariate}}
+struct UnivariateArray{N,S<:Sampleable{Univariate}} <: SampleableComponent
     sampleable::Array{S,N}
 end
 function Random.rand(rng::AbstractRNG, d::SamplerTrivial{<:UnivariateArray})
@@ -47,7 +49,7 @@ isindexable(::UnivariateArray) = false
 
 Return the same configuration every time.
 """
-struct FixedArray{S<:AbstractArray}
+struct FixedArray{S<:AbstractArray} <: SampleableComponent
     value::S
 end
 function Random.rand(::AbstractRNG, d::SamplerTrivial{<:FixedArray})
@@ -66,7 +68,7 @@ isindexable(::FixedArray) = false
 
 Fill all degrees of freedom with the same value every time.
 """
-struct FixedFill{S<:Real}
+struct FixedFill{S<:Real} <: SampleableComponent
     value::S
     dims::Dims{2}
 end
@@ -86,7 +88,7 @@ isindexable(::FixedFill) = false
 
 Sample from a provided vector of configurations.
 """
-struct ConfigurationVector{S<:AbstractVector}
+struct ConfigurationVector{S<:AbstractVector} <: SampleableComponent
     configurations::S
 end
 function Random.rand(rng::AbstractRNG, d::SamplerTrivial{<:ConfigurationVector})
@@ -108,7 +110,7 @@ isindexable(::ConfigurationVector) = true
 
 Wrap other distributions to convert them to ring polymer distributions.
 """
-struct RingPolymerWrapper{S}
+struct RingPolymerWrapper{S} <: SampleableComponent
     sampleable::S
     dims::Dims{3}
     classical::Vector{Int}
@@ -147,6 +149,8 @@ Converts a general `sampleable` that provides configurations into one of the com
 `dims` should be the size of the desired samples and must be consistent with the provided sampleable.
 """
 function SampleableComponent end
+
+SampleableComponent(sampleable::SampleableComponent, ::Dims) = sampleable
 
 function SampleableComponent(sampleable::Sampleable{Univariate}, dims::Dims{2})
     return UnivariateFill(sampleable, dims)

--- a/test/boltzmann.jl
+++ b/test/boltzmann.jl
@@ -11,6 +11,10 @@ using Random: rand!
     rand!(out, d)
     @test all(out .!== 0.0)
 
+    @test_throws DimensionMismatch DynamicalDistribution(d, d, (3,3))
     dist = DynamicalDistribution(d, d, (3,2))
+    rand(dist)
+    @test_throws DimensionMismatch DynamicalDistribution(d, d, (3,3,4))
+    dist = DynamicalDistribution(d, d, (3,2,4))
     rand(dist)
 end

--- a/test/boltzmann.jl
+++ b/test/boltzmann.jl
@@ -10,4 +10,7 @@ using Random: rand!
     out = zeros(3,2)
     rand!(out, d)
     @test all(out .!== 0.0)
+
+    dist = DynamicalDistribution(d, d, (3,2))
+    rand(dist)
 end

--- a/test/sampleable_components.jl
+++ b/test/sampleable_components.jl
@@ -38,7 +38,7 @@ end
     out = zeros(3,2,4)
     rand!(out, d)
     @test all(out .!== 0.0)
-    @test SampleableComponent([Normal() for i=1:3, j=1:2], (3,2,4)) isa RingPolymerWrapper
+    @test SampleableComponent([Normal() for i=1:3, j=1:2], (3,2,4), Int[]) isa RingPolymerWrapper
 end
 
 @testset "FixedArray" begin
@@ -70,7 +70,7 @@ end
     rand!(out, d)
     @test out == ones(3,2)
     @test SampleableComponent(1.0, (3,2)) isa FixedFill
-    @test SampleableComponent(1.0, (3,2,3)) isa RingPolymerWrapper
+    @test SampleableComponent(1.0, (3,2,3), Int[]) isa RingPolymerWrapper
 end
 
 @testset "ConfigurationVector" begin
@@ -100,28 +100,28 @@ end
 
     @testset "UnivariateFill" begin
         dsingle = UnivariateFill(Normal(), (3,2))
-        d = RingPolymerWrapper(dsingle, nbeads; classical)
+        d = RingPolymerWrapper(dsingle, nbeads, classical)
         @test eltype(d) <: RingPolymerArray
         @test rand(d) isa RingPolymerArray
     end
 
     @testset "UnivariateArray" begin
         dsingle = UnivariateArray([Normal() for i=1:3, j=1:2])
-        d = RingPolymerWrapper(dsingle, nbeads; classical)
+        d = RingPolymerWrapper(dsingle, nbeads, classical)
         @test eltype(d) <: RingPolymerArray
         @test rand(d) isa RingPolymerArray
     end
 
     @testset "FixedArray" begin
         dsingle = UnivariateArray([Normal() for i=1:3, j=1:2])
-        d = RingPolymerWrapper(dsingle, nbeads; classical)
+        d = RingPolymerWrapper(dsingle, nbeads, classical)
         @test eltype(d) <: RingPolymerArray
         @test rand(d) isa RingPolymerArray
     end
 
     @testset "FixedFill" begin
         dsingle = FixedFill(1.0, (3,2))
-        d = RingPolymerWrapper(dsingle, nbeads; classical)
+        d = RingPolymerWrapper(dsingle, nbeads, classical)
         @test eltype(d) <: RingPolymerArray
         @test rand(d) isa RingPolymerArray
         @test rand(d) == ones(3,2,4)
@@ -129,7 +129,7 @@ end
 
     @testset "ConfigurationVector" begin
         dsingle = ConfigurationVector([ones(3,2) for _=1:3])
-        d = RingPolymerWrapper(dsingle, nbeads; classical)
+        d = RingPolymerWrapper(dsingle, nbeads, classical)
         @test eltype(d) <: RingPolymerArray
         @test d[1] isa RingPolymerArray
         @test rand(d) isa RingPolymerArray


### PR DESCRIPTION
This allows the internal SampleableComponents to be used directly to initialise DynamicalDistributions. Necessary for the BoltzmannVelocity implementation.