### PR TITLE
initial version of a VelocityBoltzmann with centre of mass shift

### DIFF
--- a/src/nuclear/boltzmann.jl
+++ b/src/nuclear/boltzmann.jl
@@ -1,6 +1,6 @@
 
 """
-    VelocityBoltzmann(temperature, masses::AbstractVector, dims::Dims{2})
+    VelocityBoltzmann(temperature, masses::AbstractVector, dims::Dims{2};  centre = nothing)
 
 Generate a Boltzmann distribution of velocities for each degree of freedom.
 
@@ -11,14 +11,7 @@ Generate a Boltzmann distribution of velocities for each degree of freedom.
 * `dims` - (ndofs, natoms). `natoms` must equal `length(masses)`
 * `centre` - Vector of dimension ndofs that provides centre of mass velocity offset
 """
-function VelocityBoltzmann(temperature, masses::AbstractVector, dims::Dims{2};  centre = nothing)
-    if centre == nothing
-        return UnivariateArray([VelocityBoltzmann(temperature, masses[I[2]]) for I in CartesianIndices(dims)])
-    else
-        if size(centre,1) ≠ dims[1]
-            throw(error("centre needs to have length `ndof`"))
-        end
-        return UnivariateArray([VelocityBoltzmann(temperature, masses[I[2]]; centre = centre[I[1]]) for I in CartesianIndices(dims)])
-    end
+function VelocityBoltzmann(temperature, masses::AbstractVector, dims::Dims{2};  centre = zeros(dims))
+    return UnivariateArray([VelocityBoltzmann(temperature, masses[I[2]]; centre = centre[I]) for I in CartesianIndices(dims)])
 end
 VelocityBoltzmann(temperature, mass; centre = 0) = Normal(centre, sqrt(austrip(temperature)/mass))

--- a/src/nuclear/boltzmann.jl
+++ b/src/nuclear/boltzmann.jl
@@ -2,15 +2,23 @@
 """
     VelocityBoltzmann(temperature, masses::AbstractVector, dims::Dims{2})
 
-Generate a Boltzmann of velocities for each degree of freedom.
+Generate a Boltzmann distribution of velocities for each degree of freedom.
 
 # Arguments
 
 * `temperature` - Atomic units or Unitful
 * `masses` - Vector of masses for each atom
 * `dims` - (ndofs, natoms). `natoms` must equal `length(masses)`
+* `centre` - Vector of dimension ndofs that provides centre of mass velocity offset
 """
-function VelocityBoltzmann(temperature, masses::AbstractVector, dims::Dims{2})
-    return UnivariateArray([VelocityBoltzmann(temperature, masses[I[2]]) for I in CartesianIndices(dims)])
+function VelocityBoltzmann(temperature, masses::AbstractVector, dims::Dims{2};  centre = nothing)
+    if centre == nothing
+        return UnivariateArray([VelocityBoltzmann(temperature, masses[I[2]]) for I in CartesianIndices(dims)])
+    else
+        if size(centre,1) ≠ dims[1]
+            throw(error("centre needs to have length `ndof`"))
+        end
+        return UnivariateArray([VelocityBoltzmann(temperature, masses[I[2]]; centre = centre[I[1]]) for I in CartesianIndices(dims)])
+    end
 end
-VelocityBoltzmann(temperature, mass) = Normal(0, sqrt(austrip(temperature)/mass))
+VelocityBoltzmann(temperature, mass; centre = 0) = Normal(centre, sqrt(austrip(temperature)/mass))

--- a/src/nuclear/boltzmann.jl
+++ b/src/nuclear/boltzmann.jl
@@ -15,3 +15,24 @@ function VelocityBoltzmann(temperature, masses::AbstractVector, dims::Dims{2};  
     return UnivariateArray([VelocityBoltzmann(temperature, masses[I[2]]; centre = centre[I]) for I in CartesianIndices(dims)])
 end
 VelocityBoltzmann(temperature, mass; centre = 0) = Normal(centre, sqrt(austrip(temperature)/mass))
+
+"""
+    +(dist::VelocityBoltzmann, translation::AbstractArray)
+
+Add a permanent translation to a Velocity distribution, e.g. for a centre of mass translation component. 
+"""
+function Base.:+(dist::UnivariateArray, translation::AbstractArray)
+    if size(dist)!=size(translation)
+        throw(DimensionMismatch("Distribution and translation array must have the same size."))
+    end
+    return UnivariateArray([Normal(dist.sampleable[I].μ+translation[I], dist.sampleable[I].σ) for I in CartesianIndices(dist.sampleable)])
+end
+
+"""
+    +(dist::Normal, translation::Number)
+
+Add a permanent translation to a Velocity distribution. 
+"""
+function Base.:+(dist::Normal, translation::Number)
+    return Normal(dist.μ+convert(Float64, translation), dist.σ)
+end

--- a/src/nuclear/boltzmann.jl
+++ b/src/nuclear/boltzmann.jl
@@ -15,24 +15,3 @@ function VelocityBoltzmann(temperature, masses::AbstractVector, dims::Dims{2};  
     return UnivariateArray([VelocityBoltzmann(temperature, masses[I[2]]; centre = centre[I]) for I in CartesianIndices(dims)])
 end
 VelocityBoltzmann(temperature, mass; centre = 0) = Normal(centre, sqrt(austrip(temperature)/mass))
-
-"""
-    +(dist::VelocityBoltzmann, translation::AbstractArray)
-
-Add a permanent translation to a Velocity distribution, e.g. for a centre of mass translation component. 
-"""
-function Base.:+(dist::UnivariateArray, translation::AbstractArray)
-    if size(dist)!=size(translation)
-        throw(DimensionMismatch("Distribution and translation array must have the same size."))
-    end
-    return UnivariateArray([Normal(dist.sampleable[I].μ+translation[I], dist.sampleable[I].σ) for I in CartesianIndices(dist.sampleable)])
-end
-
-"""
-    +(dist::Normal, translation::Number)
-
-Add a permanent translation to a Velocity distribution. 
-"""
-function Base.:+(dist::Normal, translation::Number)
-    return Normal(dist.μ+convert(Float64, translation), dist.σ)
-end


### PR DESCRIPTION
 Adds an optional keyword argument so that VelocityBoltzmann can be set with a center of mass velocity. This is useful for atomic projectiles and low-dimensional models. (Diatomics are already dealt with within the DiatomicQuantised initial conditions)
 
 @clbox is this functionality that you might have already implemented in your yet-to-be-merged edits for atomic scattering?

still playing around with the behavior. Currently, I have only tested the 1D case. Looking for a quick 3D case to make sure it works. Any ideas?