### PR TITLE
PureState now restricted to density matrix diagonal indices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /Manifest.toml
+.CondaPkg/
+.CondaPkg/*
+

--- a/src/electronic/electronic.jl
+++ b/src/electronic/electronic.jl
@@ -24,7 +24,7 @@ PureState(state) = PureState(state, Diabatic())
 
 function density_matrix(d::PureState, nstates)
     density = zeros(nstates, nstates)
-    density[d.state] = 1
+    density[d.state, d.state] = 1
     return density
 end
 

--- a/src/electronic/electronic.jl
+++ b/src/electronic/electronic.jl
@@ -41,7 +41,7 @@ MixedState(state) = MixedState(state, Diabatic())
 
 function density_matrix(d::MixedState)
     density = zeros(length(d.populations), length(d.populations))
-    copy!(density[diagind(density)], d.populations)
+    density[diagind(density)] .= d.populations
     return density
 end
 

--- a/src/nuclear/boltzmann.jl
+++ b/src/nuclear/boltzmann.jl
@@ -19,6 +19,6 @@ end
 """
     VelocityBoltzmann(temperature, mass; center = 0)
 """
-function VelocityBoltzmann(temperature::Float64, mass::Float64; center::Float64 = 0)
+function VelocityBoltzmann(temperature::Number, mass::Float64; center::Float64 = 0)
     return Normal(center, sqrt(austrip(temperature)/mass))
 end

--- a/test/electronic.jl
+++ b/test/electronic.jl
@@ -3,13 +3,13 @@ using NQCDistributions
 using Unitful, UnitfulAtomic
 
 @testset "PureState" begin
-    d = PureState(1)
-    NQCDistributions.density_matrix(d, 2)
+    d = PureState(2)
+    @test NQCDistributions.density_matrix(d, 2) == [0 0; 0 1]
 end
 
 @testset "MixedState" begin
     d = MixedState([0.3, 0.4])
-    NQCDistributions.density_matrix(d)
+    @test NQCDistributions.density_matrix(d) == [0.3 0; 0 0.4]
 end
 
 @testset "FermiDiracState" begin


### PR DESCRIPTION
Currently, setting `PureState(2)` will modify the second element of the generated density matrix instead of the second diagonal element. This is now changed. 