### PR TITLE
Restored mistakenly removed docstrings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NQCDistributions"
 uuid = "657014a1-bd25-4aa2-92cb-cbcede0310ad"
 authors = ["James Gardner <james.gardner1421@gmail.com> and contributors"]
-version = "0.1.12"
+version = "0.1.13"
 
 [deps]
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"

--- a/src/dynamical_distribution.jl
+++ b/src/dynamical_distribution.jl
@@ -1,3 +1,17 @@
+"""
+Code uses the multiple dispatch in Julia by defining a certain function multiple times
+
+    So, it depends on your input to automatically choose the appropriate method
+
+    And three dispatches all return the same type DynamicalDistribution
+
+    Therefore, we should have following:
+
+        julia> dist = DynamicalDistribution(10.0, position, (1,1))
+
+        julia> dist.velocity
+        NQCDistributions.FixedFill{Float64}(10.0, (1, 1))
+"""
 
 """
     DynamicalDistribution(velocity, position, dims)
@@ -19,22 +33,6 @@ julia> d[2]
 ComponentVector{Float64}(v = [2.0;;], r = [0.1;;])
 ```
 """
-
-"""
-Code uses the multiple dispatch in Julia by defining a certain function multiple times
-    
-    So, it depends on your input to automatically choose the appropriate method 
-
-    And three dispatches all return the same type DynamicalDistribution
-
-    Therefore, we should have following:
-
-        julia> dist = DynamicalDistribution(10.0, position, (1,1))
-
-        julia> dist.velocity
-        NQCDistributions.FixedFill{Float64}(10.0, (1, 1))
-"""
-
 struct DynamicalDistribution{V,R}
     velocity::V
     position::R
@@ -117,5 +115,5 @@ end
 Base.length(d::DynamicalDistribution) = lastindex(d)
 
 function Base.iterate(d::DynamicalDistribution, state=1)
-    return state > lastindex(d) ? nothing : (d[state], state+1)
+    return state > lastindex(d) ? nothing : (d[state], state + 1)
 end

--- a/src/nuclear/boltzmann.jl
+++ b/src/nuclear/boltzmann.jl
@@ -1,6 +1,6 @@
 
 """
-    VelocityBoltzmann(temperature, masses::AbstractVector, dims::Dims{2};  center::AbstractVector = zeros(dims))
+    VelocityBoltzmann(temperature::Number, masses::AbstractVector{<:Number}, dims::Dims{2};  center::AbstractMatrix{<:Number} = zeros(dims))
 
 Generate a Boltzmann distribution of velocities for each degree of freedom.
 
@@ -11,14 +11,13 @@ Generate a Boltzmann distribution of velocities for each degree of freedom.
 * `dims` - (ndofs, natoms). `natoms` must equal `length(masses)`
 * `center` - Vector of dimension ndofs that provides centre of mass velocity offset
 """
-
-function VelocityBoltzmann(temperature::Number, masses::AbstractVector{<:Number}, dims::Dims{2};  center::AbstractMatrix{<:Number} = zeros(dims))
-    return UnivariateArray([VelocityBoltzmann(temperature, masses[I[2]]; center = center[I]) for I in CartesianIndices(dims)])
+function VelocityBoltzmann(temperature::Number, masses::AbstractVector{<:Number}, dims::Dims{2}; center::AbstractMatrix{<:Number}=zeros(dims))
+    return UnivariateArray([VelocityBoltzmann(temperature, masses[I[2]]; center=center[I]) for I in CartesianIndices(dims)])
 end
-    
+
 """
     VelocityBoltzmann(temperature, mass; center = 0)
 """
-function VelocityBoltzmann(temperature::Number, mass::Number; center::Number = 0)
-    return Normal(center, sqrt(austrip(temperature)/mass))
+function VelocityBoltzmann(temperature::Number, mass::Number; center::Number=0)
+    return Normal(center, sqrt(austrip(temperature) / mass))
 end


### PR DESCRIPTION
NQCDynamics.jl documentation wasn't building properly for newer versions since I accidentally moved some of the docstrings around. 