### PR TITLE
Add frozen atoms handling to DynamicalDistribution

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NQCDistributions"
 uuid = "657014a1-bd25-4aa2-92cb-cbcede0310ad"
 authors = ["James Gardner <james.gardner1421@gmail.com> and contributors"]
-version = "0.1.13"
+version = "0.1.14"
 
 [deps]
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"

--- a/src/dynamical_distribution.jl
+++ b/src/dynamical_distribution.jl
@@ -83,7 +83,7 @@ function Random.rand(rng::AbstractRNG, d::SamplerTrivial{<:DynamicalDistribution
     else
         i = rand(rng, UInt)
         Random.seed!(d[].rng, i)
-        return ComponentVector(v=freeze(rand(d[].rng, d[].velocity), d.frozen_atoms), r=rand(d[].rng, d[].position))
+        return ComponentVector(v=freeze(rand(d[].rng, d[].velocity), d.self.frozen_atoms), r=rand(d[].rng, d[].position))
     end
 
 end


### PR DESCRIPTION
Fix for https://github.com/NQCD/NQCDynamics.jl/issues/244. DynamicalDistributions can be provided indices of frozen atoms, which they will provide zero velocity for, regardless of the velocity input provided. 

NQCDynamics.jl updated with a constructor that takes a Simulation struct to provide size and frozen atoms information: https://github.com/NQCD/NQCDynamics.jl/pull/332