### PR TITLE
Added a NonEqDist struct as an electronics distribution type and include singleton types to select for a DensityMatrix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [compat]
 ComponentArrays = "0.11, 0.12, 0.13, 0.14, 0.15"
-DataInterpolations = "8.0.1"
+DataInterpolations = "6.5.2"
 Distributions = "0.25"
 RingPolymerArrays = "0.1"
 Unitful = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.13"
 
 [deps]
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
+DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -14,6 +15,7 @@ UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [compat]
 ComponentArrays = "0.11, 0.12, 0.13, 0.14, 0.15"
+DataInterpolations = "8.0.1"
 Distributions = "0.25"
 RingPolymerArrays = "0.1"
 Unitful = "1"

--- a/src/NQCDistributions.jl
+++ b/src/NQCDistributions.jl
@@ -7,6 +7,7 @@ using UnitfulAtomic: austrip
 using Distributions: Normal
 using RingPolymerArrays: NormalModeTransformation, transform_from_normal_modes!
 using LinearAlgebra: mul!, diagind
+using DataInterpolations: LinearInterpolation
 using ComponentArrays: ComponentVector
 
 include("sampleable_components.jl")
@@ -31,6 +32,8 @@ export PureState
 export MixedState
 export FermiDiracState
 export NonEqState # added to export new electronic state struct
+export Statistical, Binary
+export DensityMatrix
 
 include("dynamical_distribution.jl")
 export DynamicalDistribution

--- a/src/NQCDistributions.jl
+++ b/src/NQCDistributions.jl
@@ -31,6 +31,7 @@ export Adiabatic, Diabatic
 export PureState
 export MixedState
 export FermiDiracState
+export adiabatic_density_matrix
 export NonEqState # added to export new electronic state struct
 export Statistical, Binary
 export DensityMatrix

--- a/src/NQCDistributions.jl
+++ b/src/NQCDistributions.jl
@@ -30,6 +30,7 @@ export Adiabatic, Diabatic
 export PureState
 export MixedState
 export FermiDiracState
+export NonEqState # added to export new electronic state struct
 
 include("dynamical_distribution.jl")
 export DynamicalDistribution

--- a/src/electronic/electronic.jl
+++ b/src/electronic/electronic.jl
@@ -69,17 +69,16 @@ end
 
 # ------------------------------- New Electronic State Struct/Type ------------------------------- #
 """
-     NonEqState{S,T,A} <: ElectronicDistribution{S}
+    NonEqState{S,T,A} <: ElectronicDistribution{S}
 
 Electronic distribution for Fermions following a supplied non-equilibrium distribution.
 """
 struct NonEqState{S,T,A} <: ElectronicDistribution{S}
-    DistFilePath::T
-    DOSFilePath::T
+    occupation_vector::T # binary_vector from non-equilibrium distribution
     statetype::S # usually the `adiabatic()` or `diabatic()`` labels
     available_states::A # need this, in general will default to `Colon()` as with above.
 end
-function NonEqState(DistFilePath, DOSFilePath; statetype=Adiabatic(), available_states=Colon())
-    return NonEqState(DistFilePath, DOSFilePath, statetype, available_states)
+function NonEqState(state_vector, statetype=Adiabatic(), available_states=Colon())
+    return NonEqState(state_vector, statetype, available_states)
 end
 # ------------------------------------------------------------------------------------------------ #

--- a/src/electronic/electronic.jl
+++ b/src/electronic/electronic.jl
@@ -76,10 +76,11 @@ Electronic distribution for Fermions following a supplied non-equilibrium distri
 struct NonEqState{S,T,A} <: ElectronicDistribution{S}
     distribution::T # non-equilibrium distribution mapped onto model's energy grid
     dos::T # density of states distribution mapped onto the model's energy grid
+    energygrid::T
     statetype::S # usually the `adiabatic()` or `diabatic()`` labels
     available_states::A # need this, in general will default to `Colon()` as with above.
 end
-function NonEqState(distribution::Vector{<:AbstractFloat}, dos::Vector{<:AbstractFloat}; statetype=Adiabatic(), available_states=Colon())
-    return NonEqState(distribution, dos, statetype, available_states)
+function NonEqState(distribution::Vector{<:AbstractFloat}, dos::Vector{<:AbstractFloat}, energygrid::Vector{<:AbstractFloat}; statetype=Adiabatic(), available_states=Colon())
+    return NonEqState(distribution, dos, energygrid, statetype, available_states)
 end
 # ------------------------------------------------------------------------------------------------ #]

--- a/src/electronic/electronic.jl
+++ b/src/electronic/electronic.jl
@@ -78,7 +78,7 @@ Electronic distribution for Fermions following a supplied non-equilibrium distri
 struct NonEqState{S,T,A} <: ElectronicDistribution{S}
     dis_spline::T # non-equilibrium distribution spline function
     dos_spline::T # density of states distribution spline function
-    statetype::S # usually the `adiabatic()` or `diabatic()`` labels
+    statetype::S # usually the `adiabatic()` or `diabatic()` labels
     available_states::A # need this, in general will default to `Colon()` as with above.
 end
 function NonEqState(dis_spline::LinearInterpolation, dos_spline::LinearInterpolation; statetype=Adiabatic(), available_states=Colon()) 

--- a/src/electronic/electronic.jl
+++ b/src/electronic/electronic.jl
@@ -79,7 +79,7 @@ struct NonEqState{S,T,A} <: ElectronicDistribution{S}
     statetype::S # usually the `adiabatic()` or `diabatic()`` labels
     available_states::A # need this, in general will default to `Colon()` as with above.
 end
-function NonEqState(distribution::Vector{Float}, dos::Vector{Float}; statetype=Adiabatic(), available_states=Colon())
+function NonEqState(distribution::Vector{<:AbstractFloat}, dos::Vector{<:AbstractFloat}; statetype=Adiabatic(), available_states=Colon())
     return NonEqState(distribution, dos, statetype, available_states)
 end
 # ------------------------------------------------------------------------------------------------ #]

--- a/src/electronic/electronic.jl
+++ b/src/electronic/electronic.jl
@@ -74,13 +74,14 @@ end
 Electronic distribution for Fermions following a supplied non-equilibrium distribution.
 """
 struct NonEqState{S,T,A} <: ElectronicDistribution{S}
-    distribution::T # non-equilibrium distribution mapped onto model's energy grid
-    dos::T # density of states distribution mapped onto the model's energy grid
-    energygrid::T
+    dis_spline::T # non-equilibrium distribution spline function
+    dos_spline::T # density of states distribution spline function
     statetype::S # usually the `adiabatic()` or `diabatic()`` labels
     available_states::A # need this, in general will default to `Colon()` as with above.
 end
-function NonEqState(distribution::Vector{<:AbstractFloat}, dos::Vector{<:AbstractFloat}, energygrid::Vector{<:AbstractFloat}; statetype=Adiabatic(), available_states=Colon())
-    return NonEqState(distribution, dos, energygrid, statetype, available_states)
+function NonEqState(dis_spline, dos_spline; statetype=Adiabatic(), available_states=Colon()) 
+    # would be nice to include type here `dis_spline::LinearInterpolation` but would have to change package dependencies 
+    # for NQCDistributions to include `DataInterpolations` which is potentially not worth it. 
+    return NonEqState(dis_spline, dos_spline, statetype, available_states)
 end
 # ------------------------------------------------------------------------------------------------ #]

--- a/src/electronic/electronic.jl
+++ b/src/electronic/electronic.jl
@@ -4,12 +4,14 @@ struct Diabatic end
 "Singleton type for labelling states as adiabatic."
 struct Adiabatic end
 
+
 """
     ElectronicDistribution{S}
 
 Abstract type for distributions of electronic degrees of freedom only.
 """
 abstract type ElectronicDistribution{S} end
+
 
 """
     PureState{S} <: ElectronicDistribution{S}
@@ -22,7 +24,7 @@ struct PureState{S} <: ElectronicDistribution{S}
 end
 PureState(state) = PureState(state, Diabatic())
 
-function density_matrix(d::PureState, nstates)
+function adiabatic_density_matrix(d::PureState, nstates)
     density = zeros(nstates, nstates)
     density[d.state, d.state] = 1
     return density
@@ -39,7 +41,7 @@ struct MixedState{T,S} <: ElectronicDistribution{S}
 end
 MixedState(state) = MixedState(state, Diabatic())
 
-function density_matrix(d::MixedState)
+function adiabatic_density_matrix(d::MixedState)
     density = zeros(length(d.populations), length(d.populations))
     density[diagind(density)] .= d.populations
     return density
@@ -61,7 +63,7 @@ function FermiDiracState(fermi_level, temperature; statetype=Adiabatic(), availa
 end
 fermi(ϵ, μ, β) = 1 / (1 + exp(β*(ϵ - μ)))
 
-function density_matrix(d::FermiDiracState, eigenvalues)
+function adiabatic_density_matrix(d::FermiDiracState, eigenvalues)
     density = zeros(length(eigenvalues), length(eigenvalues))
     density[diagind(density)] .= fermi.(eigenvalues, d.fermi_level, d.β)
     return density
@@ -79,9 +81,32 @@ struct NonEqState{S,T,A} <: ElectronicDistribution{S}
     statetype::S # usually the `adiabatic()` or `diabatic()`` labels
     available_states::A # need this, in general will default to `Colon()` as with above.
 end
-function NonEqState(dis_spline, dos_spline; statetype=Adiabatic(), available_states=Colon()) 
-    # would be nice to include type here `dis_spline::LinearInterpolation` but would have to change package dependencies 
-    # for NQCDistributions to include `DataInterpolations` which is potentially not worth it. 
+function NonEqState(dis_spline::LinearInterpolation, dos_spline::LinearInterpolation; statetype=Adiabatic(), available_states=Colon()) 
     return NonEqState(dis_spline, dos_spline, statetype, available_states)
 end
-# ------------------------------------------------------------------------------------------------ #]
+# ------------------------------------------------------------------------------------------------ #
+
+
+
+# ---------------------------------------- Density Matrix ---------------------------------------- #
+
+
+
+"Singleton type for labelling the density matrix occupations as statistical."
+struct Statistical end
+"Singleton type for labelling the density matrix occupations as binary."
+struct Binary end
+
+
+struct DensityMatrix{T,S} <: ElectronicDistribution{S}
+    diagonal::T
+    systemtype::S
+end
+function DensityMatrix(fermi_level::Float64, temperature::Float64; statetype=Adiabatic(), available_states=Colon(), systemtype=Binary())
+    dist = FermiDiracState(austrip(fermi_level), 1/austrip(temperature), statetype, available_states)
+    return DensityMatrix(dist, systemtype)
+end
+function DensityMatrix(dis_spline::LinearInterpolation, dos_spline::LinearInterpolation; statetype=Adiabatic(), available_states=Colon(), systemtype=Binary())
+    dist = NonEqState(dis_spline, dos_spline, statetype, available_states)
+    return DensityMatrix(dist, systemtype)
+end

--- a/src/electronic/electronic.jl
+++ b/src/electronic/electronic.jl
@@ -74,11 +74,12 @@ end
 Electronic distribution for Fermions following a supplied non-equilibrium distribution.
 """
 struct NonEqState{S,T,A} <: ElectronicDistribution{S}
-    occupation_vector::T # binary_vector from non-equilibrium distribution
+    distribution::T # non-equilibrium distribution mapped onto model's energy grid
+    dos::T # density of states distribution mapped onto the model's energy grid
     statetype::S # usually the `adiabatic()` or `diabatic()`` labels
     available_states::A # need this, in general will default to `Colon()` as with above.
 end
-function NonEqState(occupation_vector::Vector{Int}; statetype=Adiabatic(), available_states=Colon())
-    return NonEqState(occupation_vector, statetype, available_states)
+function NonEqState(distribution::Vector{Float}, dos::Vector{Float}; statetype=Adiabatic(), available_states=Colon())
+    return NonEqState(distribution, dos, statetype, available_states)
 end
 # ------------------------------------------------------------------------------------------------ #]

--- a/src/electronic/electronic.jl
+++ b/src/electronic/electronic.jl
@@ -78,7 +78,7 @@ struct NonEqState{S,T,A} <: ElectronicDistribution{S}
     statetype::S # usually the `adiabatic()` or `diabatic()`` labels
     available_states::A # need this, in general will default to `Colon()` as with above.
 end
-function NonEqState(occupation_vector, statetype=Adiabatic(), available_states=Colon())
+function NonEqState(occupation_vector::Vector{Int}, statetype=Adiabatic(), available_states=Colon())
     return NonEqState(occupation_vector, statetype, available_states)
 end
 # ------------------------------------------------------------------------------------------------ #

--- a/src/electronic/electronic.jl
+++ b/src/electronic/electronic.jl
@@ -78,7 +78,7 @@ struct NonEqState{S,T,A} <: ElectronicDistribution{S}
     statetype::S # usually the `adiabatic()` or `diabatic()`` labels
     available_states::A # need this, in general will default to `Colon()` as with above.
 end
-function NonEqState(state_vector, statetype=Adiabatic(), available_states=Colon())
-    return NonEqState(state_vector, statetype, available_states)
+function NonEqState(occupation_vector, statetype=Adiabatic(), available_states=Colon())
+    return NonEqState(occupation_vector, statetype, available_states)
 end
 # ------------------------------------------------------------------------------------------------ #

--- a/src/electronic/electronic.jl
+++ b/src/electronic/electronic.jl
@@ -66,3 +66,20 @@ function density_matrix(d::FermiDiracState, eigenvalues)
     density[diagind(density)] .= fermi.(eigenvalues, d.fermi_level, d.β)
     return density
 end
+
+# ------------------------------- New Electronic State Struct/Type ------------------------------- #
+"""
+     NonEqState{S,T,A} <: ElectronicDistribution{S}
+
+Electronic distribution for Fermions following a supplied non-equilibrium distribution.
+"""
+struct NonEqState{S,T,A} <: ElectronicDistribution{S}
+    DistFilePath::T
+    DOSFilePath::T
+    statetype::S # usually the `adiabatic()` or `diabatic()`` labels
+    available_states::A # need this, in general will default to `Colon()` as with above.
+end
+function NonEqState(DistFilePath, DOSFilePath; statetype=Adiabatic(), available_states=Colon())
+    return NonEqState(DistFilePath, DOSFilePath, statetype, available_states)
+end
+# ------------------------------------------------------------------------------------------------ #

--- a/src/electronic/electronic.jl
+++ b/src/electronic/electronic.jl
@@ -78,7 +78,7 @@ struct NonEqState{S,T,A} <: ElectronicDistribution{S}
     statetype::S # usually the `adiabatic()` or `diabatic()`` labels
     available_states::A # need this, in general will default to `Colon()` as with above.
 end
-function NonEqState(occupation_vector::Vector{Int}, statetype=Adiabatic(), available_states=Colon())
+function NonEqState(occupation_vector::Vector{Int}; statetype=Adiabatic(), available_states=Colon())
     return NonEqState(occupation_vector, statetype, available_states)
 end
-# ------------------------------------------------------------------------------------------------ #
+# ------------------------------------------------------------------------------------------------ #]

--- a/test/electronic.jl
+++ b/test/electronic.jl
@@ -4,15 +4,15 @@ using Unitful, UnitfulAtomic
 
 @testset "PureState" begin
     d = PureState(2)
-    @test NQCDistributions.density_matrix(d, 2) == [0 0; 0 1]
+    @test NQCDistributions.adiabatic_density_matrix(d, 2) == [0 0; 0 1]
 end
 
 @testset "MixedState" begin
     d = MixedState([0.3, 0.4])
-    @test NQCDistributions.density_matrix(d) == [0.3 0; 0 0.4]
+    @test NQCDistributions.adiabatic_density_matrix(d) == [0.3 0; 0 0.4]
 end
 
 @testset "FermiDiracState" begin
     d = FermiDiracState(0.0, 300u"K")
-    NQCDistributions.density_matrix(d, austrip.((-1:0.01:1) .* u"eV"))
+    NQCDistributions.adiabatic_density_matrix(d, austrip.((-1:0.01:1) .* u"eV"))
 end


### PR DESCRIPTION
Added new types and structs to allow for selectivity of a NonEquilibrium electron density as the electronic state, or, to select that you want to describe your electronic system in a density matrix formulation to work with issue #380.
